### PR TITLE
Remove the `Theca` prefix from various data structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ the bug, and if you're really awesome a test case that exposes it.
 ### TODO
 
 * clean-ups/optimizations pretty much everywhere
-* `ThecaProfile` and `ThecaItem` and assosiated functions should be moved out of `src/theca/lib.rs`
+* `Profile` and `Item` and assosiated functions should be moved out of `src/theca/lib.rs`
   to their own file
 * `list-profiles` should be alphabetic
 * `bash_complete.sh` could use a lot of improvement, `_theca` also, but less...

--- a/src/bin/theca.rs
+++ b/src/bin/theca.rs
@@ -14,8 +14,8 @@ extern crate theca;
 extern crate docopt;
 
 use docopt::Docopt;
-use theca::{Args, ThecaProfile, setup_args, parse_cmds, version};
-use theca::errors::ThecaError;
+use theca::{Args, Profile, setup_args, parse_cmds, version};
+use theca::errors::Error;
 use std::process::exit;
 
 static USAGE: &'static str = "
@@ -90,14 +90,14 @@ Miscellaneous:
     -v, --version                       Display the version of theca and exit.
 ";
 
-fn theca_main() -> Result<(), ThecaError> {
+fn theca_main() -> Result<(), Error> {
     let mut args: Args = try!(Docopt::new(USAGE)
                                   .unwrap()
                                   .version(Some(version()))
                                   .decode());
     try!(setup_args(&mut args));
 
-    let (mut profile, profile_fingerprint) = try!(ThecaProfile::new(&args.flag_profile,
+    let (mut profile, profile_fingerprint) = try!(Profile::new(&args.flag_profile,
                                                                     &args.flag_profile_folder,
                                                                     &args.flag_key,
                                                                     args.cmd_new_profile,

--- a/src/theca/errors.rs
+++ b/src/theca/errors.rs
@@ -7,12 +7,12 @@
 // licensed under the MIT license <http://opensource.org/licenses/MIT>
 //
 // errors.rs
-//   definitions for ThecaError, a catch-all for converting various
+//   definitions for Error, a catch-all for converting various
 //   lib errors.
 
 use std::fmt;
 use std::convert::From;
-use std::error::Error;
+use std::error::Error as StdError;
 use std::io::Error as IoError;
 use std::string::FromUtf8Error;
 use std::time::SystemTimeError;
@@ -23,6 +23,7 @@ use docopt;
 use term;
 
 pub use self::ErrorKind::{TermError, InternalIoError, GenericError};
+pub type Result<T> = ::std::result::Result<T, Error>;
 
 #[derive(Debug)]
 pub enum ErrorKind {
@@ -32,24 +33,24 @@ pub enum ErrorKind {
 }
 
 #[derive(Debug)]
-pub struct ThecaError {
+pub struct Error {
     pub kind: ErrorKind,
     pub desc: String,
     pub detail: Option<String>,
 }
 
-impl fmt::Display for ThecaError {
+impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", &self.desc)
     }
 }
 
-impl Error for ThecaError {
+impl StdError for Error {
     fn description(&self) -> &str {
         &self.desc
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&StdError> {
         match self.kind {
             ErrorKind::TermError(ref e) => Some(e),
             ErrorKind::InternalIoError(ref e) => Some(e),
@@ -61,7 +62,7 @@ impl Error for ThecaError {
 macro_rules! specific_fail {
     ($short:expr) => {
         return Err(::std::convert::From::from(
-            ThecaError {
+            Error {
                 kind: GenericError,
                 desc: $short,
                 detail: None
@@ -90,9 +91,9 @@ macro_rules! try_errno {
     }
 }
 
-impl From<EncoderError> for ThecaError {
-    fn from(err: EncoderError) -> ThecaError {
-        ThecaError {
+impl From<EncoderError> for Error {
+    fn from(err: EncoderError) -> Error {
+        Error {
             kind: GenericError,
             desc: err.description().to_string(),
             detail: None,
@@ -100,9 +101,9 @@ impl From<EncoderError> for ThecaError {
     }
 }
 
-impl From<IoError> for ThecaError {
-    fn from(err: IoError) -> ThecaError {
-        ThecaError {
+impl From<IoError> for Error {
+    fn from(err: IoError) -> Error {
+        Error {
             kind: GenericError,
             desc: err.description().into(),
             detail: None,
@@ -110,9 +111,9 @@ impl From<IoError> for ThecaError {
     }
 }
 
-impl From<term::Error> for ThecaError {
-    fn from(err: term::Error) -> ThecaError {
-        ThecaError {
+impl From<term::Error> for Error {
+    fn from(err: term::Error) -> Error {
+        Error {
             desc: err.description().into(),
             kind: TermError(err),
             detail: None,
@@ -120,9 +121,9 @@ impl From<term::Error> for ThecaError {
     }
 }
 
-impl From<(ErrorKind, &'static str)> for ThecaError {
-    fn from((kind, desc): (ErrorKind, &'static str)) -> ThecaError {
-        ThecaError {
+impl From<(ErrorKind, &'static str)> for Error {
+    fn from((kind, desc): (ErrorKind, &'static str)) -> Error {
+        Error {
             kind: kind,
             desc: desc.to_string(),
             detail: None,
@@ -130,9 +131,9 @@ impl From<(ErrorKind, &'static str)> for ThecaError {
     }
 }
 
-impl From<SystemTimeError> for ThecaError {
-    fn from(err: SystemTimeError) -> ThecaError {
-        ThecaError {
+impl From<SystemTimeError> for Error {
+    fn from(err: SystemTimeError) -> Error {
+        Error {
             kind: GenericError,
             desc: err.description().into(),
             detail: None,
@@ -140,9 +141,9 @@ impl From<SystemTimeError> for ThecaError {
     }
 }
 
-impl From<ParseError> for ThecaError {
-    fn from(err: ParseError) -> ThecaError {
-        ThecaError {
+impl From<ParseError> for Error {
+    fn from(err: ParseError) -> Error {
+        Error {
             kind: GenericError,
             desc: format!("time parsing error: {}", err),
             detail: None,
@@ -150,9 +151,9 @@ impl From<ParseError> for ThecaError {
     }
 }
 
-impl From<FromUtf8Error> for ThecaError {
-    fn from(err: FromUtf8Error) -> ThecaError {
-        ThecaError {
+impl From<FromUtf8Error> for Error {
+    fn from(err: FromUtf8Error) -> Error {
+        Error {
             kind: GenericError,
             desc: format!("is this profile encrypted? ({})", err),
             detail: None,
@@ -160,9 +161,9 @@ impl From<FromUtf8Error> for ThecaError {
     }
 }
 
-impl From<SymmetricCipherError> for ThecaError {
-    fn from(_: SymmetricCipherError) -> ThecaError {
-        ThecaError {
+impl From<SymmetricCipherError> for Error {
+    fn from(_: SymmetricCipherError) -> Error {
+        Error {
             kind: GenericError,
             desc: "invalid encryption key".to_string(),
             detail: None,
@@ -170,9 +171,9 @@ impl From<SymmetricCipherError> for ThecaError {
     }
 }
 
-impl From<docopt::Error> for ThecaError {
-    fn from(err: docopt::Error) -> ThecaError {
-        ThecaError {
+impl From<docopt::Error> for Error {
+    fn from(err: docopt::Error) -> Error {
+        Error {
             kind: GenericError,
             desc: err.to_string(),
             detail: None,
@@ -180,9 +181,9 @@ impl From<docopt::Error> for ThecaError {
     }
 }
 
-impl From<fmt::Error> for ThecaError {
-    fn from(_: fmt::Error) -> ThecaError {
-        ThecaError {
+impl From<fmt::Error> for Error {
+    fn from(_: fmt::Error) -> Error {
+        Error {
             kind: GenericError,
             desc: "formatting error".to_string(),
             detail: None,

--- a/src/theca/lineformat.rs
+++ b/src/theca/lineformat.rs
@@ -11,8 +11,8 @@
 //   tries to construct a line format that won't overflow the console
 //   width.
 
-use errors::ThecaError;
-use {ThecaItem, Status};
+use errors::Result;
+use {Item, Status};
 use utils::termsize;
 
 #[derive(Clone, Copy)]
@@ -25,10 +25,10 @@ pub struct LineFormat {
 }
 
 impl LineFormat {
-    pub fn new(items: &Vec<ThecaItem>,
+    pub fn new(items: &Vec<Item>,
                condensed: bool,
                search: bool)
-               -> Result<LineFormat, ThecaError> {
+               -> Result<LineFormat> {
         // get termsize :>
         let console_width = termsize();
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,10 +1,10 @@
 extern crate theca;
 
-use theca::{Status, ThecaProfile};
+use theca::{Status, Profile};
 
 #[test]
 fn test_add_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -18,7 +18,7 @@ fn test_add_note() {
 
 #[test]
 fn test_add_started_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -32,7 +32,7 @@ fn test_add_started_note() {
 
 #[test]
 fn test_add_urgent_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -46,7 +46,7 @@ fn test_add_urgent_note() {
 
 #[test]
 fn test_add_basic_body_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -60,7 +60,7 @@ fn test_add_basic_body_note() {
 
 #[test]
 fn test_add_full_basic_body_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -74,7 +74,7 @@ fn test_add_full_basic_body_note() {
 
 #[test]
 fn test_edit_note_title() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -89,7 +89,7 @@ fn test_edit_note_title() {
 
 #[test]
 fn test_edit_note_status() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -114,7 +114,7 @@ fn test_edit_note_status() {
 
 #[test]
 fn test_edit_note_body_basic() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -129,7 +129,7 @@ fn test_edit_note_body_basic() {
 
 #[test]
 fn test_edit_full_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -144,7 +144,7 @@ fn test_edit_full_note() {
 
 #[test]
 fn test_delete_single_note() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -155,7 +155,7 @@ fn test_delete_single_note() {
 
 #[test]
 fn test_delete_some_notes() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };
@@ -175,7 +175,7 @@ fn test_delete_some_notes() {
 
 #[test]
 fn test_clear_notes() {
-    let mut p = ThecaProfile {
+    let mut p = Profile {
         encrypted: false,
         notes: vec![]
     };

--- a/tests/lineformat.rs
+++ b/tests/lineformat.rs
@@ -1,10 +1,10 @@
 extern crate theca;
 
-use theca::{Status, ThecaItem};
+use theca::{Status, Item};
 use theca::lineformat::{LineFormat};
 
 struct LineTest {
-    input_notes: Vec<ThecaItem>,
+    input_notes: Vec<Item>,
     condensed: bool,
     search: bool,
     expected_format: LineFormat
@@ -28,14 +28,14 @@ fn test_new_line_format_basic() {
     let basic_tests = vec![
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -55,14 +55,14 @@ fn test_new_line_format_basic() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -90,14 +90,14 @@ fn test_new_line_format_statuses() {
     let status_tests = vec![
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::Started,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -117,14 +117,14 @@ fn test_new_line_format_statuses() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -144,14 +144,14 @@ fn test_new_line_format_statuses() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "".to_string(),
@@ -179,14 +179,14 @@ fn test_new_line_format_body() {
     let body_tests = vec![
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -206,14 +206,14 @@ fn test_new_line_format_body() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -233,14 +233,14 @@ fn test_new_line_format_body() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -260,14 +260,14 @@ fn test_new_line_format_body() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -295,14 +295,14 @@ fn test_new_line_format_full() {
     let body_tests = vec![
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::Started,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -322,14 +322,14 @@ fn test_new_line_format_full() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::Started,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -349,14 +349,14 @@ fn test_new_line_format_full() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::Urgent,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),
@@ -376,14 +376,14 @@ fn test_new_line_format_full() {
         },
         LineTest {
             input_notes: vec![
-                ThecaItem {
+                Item {
                     id: 1,
                     title: "a title".to_string(),
                     body: "".to_string(),
                     status: Status::NoStatus,
                     last_touched: "2015-01-22 19:43:24 -0800".to_string()
                 },
-                ThecaItem {
+                Item {
                     id: 2,
                     title: "a longer title".to_string(),
                     body: "this is a body".to_string(),


### PR DESCRIPTION
We don't really need data structures to have the `Theca` prefix. `ThecaProfile` can just be `Profile`, etc.